### PR TITLE
Renaming the name of the Pod to AeroGear-Sync for consistency.

### DIFF
--- a/AeroGearSync.podspec
+++ b/AeroGearSync.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name         = "AeroGearSync"
+  s.name         = "AeroGear-Sync"
   s.version      = "0.1.0"
   s.summary      = "An iOS Sync Engine for AeroGear Differential Synchronization"
   s.homepage     = "https://github.com/aerogear/aerogear-sync-server"


### PR DESCRIPTION
Motivation:
I did not look at the other AeroGear pod names and hence did not notice
that the naming convention was to use '-' and not camel case for the pod
name.