### PR TITLE
Adding Cocoapods image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AeroGear iOS Differential Synchronization Client Engine [![Build Status](https://travis-ci.org/aerogear/aerogear-ios-sync.png)](https://travis-ci.org/aerogear/aerogear-ios-sync)
+# AeroGear iOS Differential Synchronization Client Engine [![Build Status](https://travis-ci.org/aerogear/aerogear-ios-sync.png)](https://travis-ci.org/aerogear/aerogear-ios-sync) [![Pod Version](http://img.shields.io/cocoapods/v/AeroGearSync.svg?style=flat)](http://cocoadocs.org/docsets/AeroGearSync/)
 This project represents a client side implementation for [AeroGear Differential 
 Synchronization (DS) Server](https://github.com/aerogear/aerogear-sync-server/).
 


### PR DESCRIPTION
Suggestion for adding a cocoapods image. 
See [README.md](https://github.com/danbev/aerogear-ios-sync/tree/cocoapods-image#aerogear-ios-differential-synchronization-client-engine--) to see what this would look like.