### PR TITLE
Checking for already received patches before checking backup.

### DIFF
--- a/AeroGearSync/ClientSyncEngine.swift
+++ b/AeroGearSync/ClientSyncEngine.swift
@@ -67,12 +67,12 @@ public class ClientSyncEngine<CS:ClientSynchronizer, D:DataStore where CS.T == D
     private func patchShadow(patchMessage: P) -> ShadowDocument<T>? {
         if var shadow = dataStore.getShadowDocument(patchMessage.documentId, clientId: patchMessage.clientId) {
             for edit in patchMessage.edits {
-                if (edit.clientVersion < shadow.clientVersion && !self.isSeedVersion(edit)) {
-                    shadow = restoreBackup(shadow, edit: edit)!
-                    continue
-                }
                 if edit.serverVersion < shadow.serverVersion {
                     dataStore.removeEdit(edit)
+                    continue
+                }
+                if (edit.clientVersion < shadow.clientVersion && !self.isSeedVersion(edit)) {
+                    shadow = restoreBackup(shadow, edit: edit)!
                     continue
                 }
                 if edit.serverVersion == shadow.serverVersion && edit.clientVersion == shadow.clientVersion || isSeedVersion(edit) {

--- a/AeroGearSync/ClientSyncEngine.swift
+++ b/AeroGearSync/ClientSyncEngine.swift
@@ -48,9 +48,9 @@ public class ClientSyncEngine<CS:ClientSynchronizer, D:DataStore where CS.T == D
             dataStore.saveEdits(edit)
             let patched = synchronizer.patchShadow(edit, shadow: shadow)
             dataStore.saveShadowDocument(incrementClientVersion(patched))
-            let edits = dataStore.getEdits(clientDocument.id, clientId: clientDocument.clientId)
-
-            return synchronizer.createPatchMessage(clientDocument.id, clientId: clientDocument.clientId, edits: edits!)
+            if let edits = dataStore.getEdits(clientDocument.id, clientId: clientDocument.clientId) {
+                return synchronizer.createPatchMessage(clientDocument.id, clientId: clientDocument.clientId, edits: edits)
+            }
         }
         return Optional.None
     }
@@ -72,8 +72,9 @@ public class ClientSyncEngine<CS:ClientSynchronizer, D:DataStore where CS.T == D
                     continue
                 }
                 if (edit.clientVersion < shadow.clientVersion && !self.isSeedVersion(edit)) {
-                    shadow = restoreBackup(shadow, edit: edit)!
-                    continue
+                    if let shadow = restoreBackup(shadow, edit: edit) {
+                        continue
+                    }
                 }
                 if edit.serverVersion == shadow.serverVersion && edit.clientVersion == shadow.clientVersion || isSeedVersion(edit) {
                     let patched = synchronizer.patchShadow(edit, shadow: shadow)


### PR DESCRIPTION
Motivation:
Currently we are checking if we need to restore from a backup copy would
be required if a patch message was never recieved by the server. This is
done before we check if we already have the patch in question. I believe
that this is wrong and that we should be checking if we have the patch
already first, giving us the chance to discard it, before going down the
backup route.

I only noticed this when using the server-wildfly module and never with
the server-netty module. This might just be bad luck that it never
showed up.

To test this you'll need to build and start the [server-wildfly](https://github.com/danbev/aerogear-sync-server/tree/wildfly-updates) module: 
1. ```cd server/server-wildfly; mvn clean install wildfly:run```
2. The above command will start the server listening to port ```8080``` and the context path to use will be ```/sync```. So we need to update ```Info.plist``` accordingly. 

To see the issue in question you can simply run against the server above with out the change in this PR. 

This has also highlighted that we need to do better error handling. This issue actually crashed the app because of forced-unwrapping of an optional. I suspect that this happens in other places as well (bows head in shame). I've created [AGIOS-407](https://issues.jboss.org/browse/AGIOS-407) for this. 