### PR TITLE
remove custom repo and use latest jsontools rel.

### DIFF
--- a/AeroGearSync.podspec
+++ b/AeroGearSync.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.subspec 'JSONPatch' do |jsonpatch|
      jsonpatch.source_files = 'AeroGearSync-JSONPatch/*.{h,swift}'
      jsonpatch.dependency  'AeroGearSync/Core'     
-     jsonpatch.dependency  'JSONTools', '1.0.4-patched'
+     jsonpatch.dependency  'JSONTools', '1.0.5'
   end
   
 end

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,3 @@
-source 'https://github.com/aerogear/Cocoapods-repo.git'
 source 'https://github.com/CocoaPods/Specs.git'
 
 xcodeproj 'AeroGearSync.xcodeproj'
@@ -6,11 +5,11 @@ platform :ios, '8.0'
 use_frameworks!
 
 target 'AeroGearSync-JSONPatch' do
-    pod 'JSONTools', '1.0.4-patched'
+    pod 'JSONTools', '1.0.5'
 end
 
 target 'AeroGearSync-JSONPatchTests' do
-    pod 'JSONTools', '1.0.4-patched'
+    pod 'JSONTools', '1.0.5'
 end
 
 target 'AeroGearSync-DiffMatchPatch' do


### PR DESCRIPTION
Motivation:
since JSONTools patched their library in the latest 1.0.5 release, [fixing the issue reported](https://github.com/grgcombs/JSONTools/issues/4) there is no point to keep the custom cocoapods repo with the patched artifacts and we can safely remove it and use the official released ones.

To test:

- ```pod install``` and run the tests target, notice there are no issues on build, and all tests succeed as expected.
-  clone the cookbook demo 'https://github.com/cvasilak/aerogear-ios-cookbook/tree/custom.repo' repo, use JsonPatch variant demo and connect to the latest 'master' sync server. Notice demo works as expected too.

@corinnekrych mind to look and merge