### PR TITLE
match travis 'beta-xcode6.3' osx_image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode63
+osx_image: beta-xcode6.3
 xcode_workspace: AeroGearSync.xcworkspace
 xcode_scheme: AeroGearSync
 xcode_sdk: iphonesimulator


### PR DESCRIPTION
comply with the [latest 'osx_image' update](http://blog.travis-ci.com/2015-05-26-xcode-63-beta-general-availability/) on Travis.